### PR TITLE
Added feature to ban jwt after updating user credentials

### DIFF
--- a/utils/database.js
+++ b/utils/database.js
@@ -50,6 +50,10 @@ const db = new sqlite.Database(DBFILE, (err) => {
     'CREATE TABLE user_roles(UserId integer not null, RoleId integer not null, primary key(UserId, RoleId), foreign key(UserId) references users(Id), foreign key(RoleId) references roles(Id))',
     cb
   );
+  db.run(
+    'CREATE TABLE banned_tokens(Id integer primary key autoincrement, Token text not null)',
+    cb
+  );
   db.all('SELECT * from Roles', (_err, rows) => {
     if (rows.length === 0) {
       db.run("INSERT into roles(Role) values ('USER'), ('ADMIN')", cb);


### PR DESCRIPTION
Added table for banned jwt
When updating user credentials the used token gets banned and a new jwt will be issued
